### PR TITLE
DPSPayment indexes for better select performance

### DIFF
--- a/code/DPSPayment/DPSPayment.php
+++ b/code/DPSPayment/DPSPayment.php
@@ -7,7 +7,7 @@
  */	
 class DPSPayment extends Payment {
 	static $db = array(
-		'TxnRef' => 'Text',
+		'TxnRef' => 'Varchar(1024)',
 		'TxnType' => "Enum('Purchase,Auth,Complete,Refund,Validate', 'Purchase')",
 		'AuthCode' => 'Varchar(22)',
 		'MerchantReference' => 'Varchar(64)',
@@ -22,6 +22,10 @@ class DPSPayment extends Payment {
 		'CardHolderName' => 'Varchar(255)', 
 		'DateExpiry' => 'Varchar(4)', // four digits (mm/yy)
 		'TimeOutDate' => 'SS_Datetime'
+	);
+
+	static $indexes = array(
+		'TxnRef' => true,
 	);
 	
 	static $has_one = array(


### PR DESCRIPTION
On an table with 70k orders on SQL Server, we saw 15s times for a simple
"SELECT FROM ... WHERE TxnRef = ...".
