### PR TITLE
BUGFIX Ensure XML is well formed when rebuilding the XML response. XML i...

### DIFF
--- a/code/DPSPayment/thirdparty/dps_hosted_helper/PxPayMessage.php
+++ b/code/DPSPayment/thirdparty/dps_hosted_helper/PxPayMessage.php
@@ -98,7 +98,7 @@ class PxPayMessage {
 			
 		$xml  = "<$root>";
     	while (list($prop, $val) = each($arr))
-        	$xml .= "<$prop>$val</$prop>" ;
+        	$xml .= "<$prop>".htmlspecialchars($val, ENT_QUOTES, 'UTF-8')."</$prop>" ;
 
 		$xml .= "</$root>";
 		


### PR DESCRIPTION
...s badly formed when user uses special chars like & or > in the card holder name field. Typical error: "[Warning] simplexml_load_string() [function.simplexml-load-string]: Entity: line 1: parser error : xmlParseEntityRef: no name" when the response is parsed afterwards

A similar PR has been lodged to https://github.com/frankmullenger/silverstripe-payment-paymentexpress/pull/6 for the splitted module
