### PR TITLE
explicitly define routing for PaymentProcessor_GatewayHosted controller

### DIFF
--- a/_config/Payment.yaml
+++ b/_config/Payment.yaml
@@ -3,4 +3,4 @@ name: Payment
 
 Director:
   rules:
-    'payment/$MethodName/$Action/$ID': 'PaymentProcessor_GatewayHosted'
+    'PaymentProcessor_GatewayHosted//$Action!/$ID/$OtherID': 'PaymentProcessor_GatewayHosted'

--- a/_config/Payment.yaml
+++ b/_config/Payment.yaml
@@ -3,4 +3,4 @@ name: Payment
 
 Director:
   rules:
-    'PaymentProcessor_GatewayHosted//$Action!/$ID/$OtherID': 'PaymentProcessor_GatewayHosted'
+    'PaymentProcessor_GatewayHosted': 'PaymentProcessor_GatewayHosted'


### PR DESCRIPTION
Fixes issue where hosted gateway returns the user to a controller/action that is no longer accessible in ss 3.2. From what I can see the existing rule 'payment/$MethodName/$Action/$ID' was never used